### PR TITLE
Add more explanation about the workaround to deploy Prestashop.

### DIFF
--- a/prestashop-build.sh
+++ b/prestashop-build.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 readarray -t  dirs < .platform-read-write-dirs
-#move files away.
-# loop through array(dirs)
+
+# Loop through array(dirs).
 for dir in "${dirs[@]}"
 do
+ #  Temporarly rename folders.
  mv  "$dir" "$dir-init"
+ #  Recreate those folders that will be mounted by Platform.sh.
  mkdir "$dir"
 done


### PR DESCRIPTION
Prestashop required many folders to be writable. Platform.sh allows this by mounting those folders. 

That's the reason we need to:
* Rename those folders (*build hook*).
* Create and mount the folders that need to be writable.
* Copy the content of the renamed folders back to the mounts (*deploy hook*).