### PR TITLE
Fix install of D8

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -4,6 +4,9 @@
  * Platform.sh example settings.php file for Drupal 8.
  */
 
+// Install with the 'standard' profile for this example.
+$settings['install_profile'] = 'standard';
+
 // You should modify the hash_salt so that it is specific to your application.
 $settings['hash_salt'] = '4946c1912834b8477cc70af309a2c30dcec24c2103c724ff30bf13b4c10efd82';
 


### PR DESCRIPTION
Drupal now needs the install profile to be specified in settings.php to prevent it complaining about config.