### PR TITLE
Add drush-backups directory to fix sql-sync with Drush 7 (Drupal 7)

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -31,6 +31,7 @@ mounts:
     "/public/sites/default/files": "shared:files/files"
     "/tmp": "shared:files/tmp"
     "/private": "shared:files/private"
+    "/drush-backups": "shared:files/drush-backups"
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:


### PR DESCRIPTION
Drush 7.0.0 was released on 20/05/2015