### PR TITLE
Update to Drupal 8 beta 12

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -4,15 +4,19 @@
 # The name of this app. Must be unique within a project.
 name: php
 
+# The runtime the application uses.
+type: "php:5.6"
+
+# Configuration of the build of this application.
+build:
+    flavor: drupal
+
 # The build-time dependencies of the app.
 # Note: Drush 7.0.0 (stable) is released, but it purposefully does not work
 # with Drupal 8.
 dependencies:
     php:
-        "drush/drush": "7.0.0-rc2"
-
-# The toolstack used to build the application.
-toolstack: "php:drupal"
+        "drush/drush": "8.0.0-beta12"
 
 # The relationships of the application with services or other applications.
 # The left-hand side is the name of the relationship as it will be exposed

--- a/project.make
+++ b/project.make
@@ -3,4 +3,4 @@ core = 8.x
 
 ; Drupal core.
 projects[drupal][type] = core
-projects[drupal][version] = 8.0.0-beta11
+projects[drupal][version] = 8.0.0-beta12


### PR DESCRIPTION
 * Use PHP 5.6, as Drupal 8 now requires PHP > 5.5
 * Update Drupal to 8.0.0-beta12
 * Update Drush to 8.0.0-beta12
