### PR TITLE
Use dev-master of Drush for D8

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -12,11 +12,9 @@ build:
     flavor: drupal
 
 # The build-time dependencies of the app.
-# Note: Drush 7.0.0 (stable) is released, but it purposefully does not work
-# with Drupal 8.
 dependencies:
     php:
-        "drush/drush": "8.0.0-beta14"
+        "drush/drush": "dev-master"
 
 # The relationships of the application with services or other applications.
 # The left-hand side is the name of the relationship as it will be exposed


### PR DESCRIPTION
Drush 8.0.0-beta14 is broken for the latest D8