### PR TITLE
D7: make the document root explicit

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -21,7 +21,7 @@ relationships:
 # The configuration of app when it is exposed to the web.
 web:
     # The public directory of the app, relative to its root.
-    document_root: "/"
+    document_root: "/public"
     # The front-controller script to send non-static requests to.
     passthru: "/index.php"
 


### PR DESCRIPTION
At the moment "/" is magically translated to "/public". This makes it explicit and more forwards-compatible.