### PR TITLE
D8: Deploy configuration

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -39,7 +39,6 @@ disk: 2048
 mounts:
     "/web/sites/default/files": "shared:files/files"
     "/tmp": "shared:files/tmp"
-    "/config": "shared:files/config"
     "/private": "shared:files/private"
 
 # The hooks executed at various points in the lifecycle of the application.
@@ -49,6 +48,8 @@ hooks:
     # We run deploy hook after your application has been deployed and started.
     deploy: |
       cd web
+      drush cr
+      drush -y config-import
       drush -y updatedb
 
 # The configuration of scheduled execution.


### PR DESCRIPTION
Any professional Drupal developer has been using code-driven development for years, and with D8 Configuration Management makes it so easy that nobody has an excuse for not using it. 

Rather than storing configuration on a mounted partition (which made sense when the active configuration was still automatically exported to the filesystem), we should deploy configuration files the same way we deploy code.

This is one of the changes that we do for every single project, it would be great to have it as the default.